### PR TITLE
Adding sast-synk-check Parameters To Add Report in Synk UI And Ignore File Paths

### DIFF
--- a/.tekton/kruize-mvp-pull-request.yaml
+++ b/.tekton/kruize-mvp-pull-request.yaml
@@ -363,6 +363,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=kruize-mvpdemo --report --org=2b164c81-f9ad-458c-b23d-c7708c1fa6cf"
+      - name: IGNORE_FILE_PATHS
+        value: "autotune_mvp/scripts/kruize_metrics.py"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/kruize-mvp-push.yaml
+++ b/.tekton/kruize-mvp-push.yaml
@@ -360,6 +360,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=kruize-mvpdemo --report --org=2b164c81-f9ad-458c-b23d-c7708c1fa6cf"
+      - name: IGNORE_FILE_PATHS
+        value: "autotune_mvp/scripts/kruize_metrics.py"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
This PR - 

- Adds the Synk ORG label to existing Tekton tasks, to add the report to synk UI.
- Adds IGNORE_FILE_PATHS parameter to ignore certain files. 
