### PR TITLE
Included skipTests at copying dependencies at build time

### DIFF
--- a/Containerfile_mvp
+++ b/Containerfile_mvp
@@ -35,7 +35,7 @@ WORKDIR $AUTOTUNE_HOME/src/autotune
 
 # Copy only the pom.xml and download the dependencies
 COPY autotune_mvp/pom.xml $AUTOTUNE_HOME/src/autotune/
-RUN mvn -f pom.xml install dependency:copy-dependencies
+RUN mvn -f pom.xml install dependency:copy-dependencies -DskipTests
 
 # Now copy the sources and compile and package them
 COPY autotune_mvp/src $AUTOTUNE_HOME/src/autotune/src/


### PR DESCRIPTION
Included skipTests at copying dependencies at build time to address build running tests while copying dependencies based on changes in autotune upstream repo

## Summary by Sourcery

Build:
- Configure the container build process to respect a skipTests flag while copying dependencies, preventing tests from running during image builds.