### PR TITLE
Skip tests in dependency copying step to address the build failure

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,7 +35,7 @@ WORKDIR $AUTOTUNE_HOME/src/autotune
 
 # Copy only the pom.xml and download the dependencies
 COPY autotune/pom.xml $AUTOTUNE_HOME/src/autotune/
-RUN mvn -f pom.xml install dependency:copy-dependencies
+RUN mvn -f pom.xml install dependency:copy-dependencies -DskipTests
 
 # Now copy the sources and compile and package them
 COPY autotune/src $AUTOTUNE_HOME/src/autotune/src/


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update container Maven dependency copy step to skip tests during image build.