### PR TITLE
Update dockerFile to include jdk.net package

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -43,7 +43,7 @@ RUN mvn -f pom.xml clean package
 COPY autotune/migrations target/bin/migrations
 
 # Create a jlinked JRE specific to the App
-RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
+RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec,jdk.net --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
 
 ##########################################################
 #            Runtime Docker Image


### PR DESCRIPTION
This PR updates 'jdk.net' package installation in dockerFile to fix the AWS cloudwatch issue with the new Apache http client library used transitively in Kruize.

## Summary by Sourcery

Build:
- Update Containerfile jlink configuration to add the jdk.net module to the generated runtime image.