### PR TITLE
Update dockerFile to include jdk.net package

### DIFF
--- a/Containerfile_mvp
+++ b/Containerfile_mvp
@@ -43,7 +43,7 @@ RUN mvn -f pom.xml clean package
 COPY autotune_mvp/migrations target/bin/migrations
 
 # Create a jlinked JRE specific to the App
-RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
+RUN jlink --strip-debug --compress 2 --no-header-files --no-man-pages --module-path $AUTOTUNE_HOME/java/openjdk/jmods --add-modules java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.security.jgss,java.sql,java.xml,jdk.compiler,jdk.httpserver,jdk.unsupported,jdk.crypto.ec,jdk.net --exclude-files=**java_**.properties,**J9TraceFormat**.dat,**OMRTraceFormat**.dat,**j9ddr**.dat,**public_suffix_list**.dat --output jre
 
 ##########################################################
 #            Runtime Docker Image


### PR DESCRIPTION
This PR updates 'jdk.net' package installation in dockerFile to fix the AWS cloudwatch issue with the new Apache http client library used transitively in Kruize.

## Summary by Sourcery

Update the container image to ensure the JDK networking package is available for components using the new Apache HTTP client library.

Bug Fixes:
- Resolve AWS CloudWatch connectivity issues caused by missing JDK networking support in the container image.

Build:
- Adjust Docker/Containerfile package installation to include the JDK networking package required by the new HTTP client dependency.